### PR TITLE
Use a better weak map implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   "readmeFilename": "README.md",
   "gitHead": "c561ef237cb3b66576b0e9e599f729628a209649",
   "dependencies": {
-    "weakmap": "0.0.6"
+    "weak-map": "^1.0.5"
   }
 }

--- a/webglew.js
+++ b/webglew.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var weakMap = typeof WeakMap === 'undefined' ? require('weakmap') : WeakMap
+var weakMap = typeof WeakMap === 'undefined' ? require('weak-map') : WeakMap
 
 var WebGLEWStruct = new weakMap()
 


### PR DESCRIPTION
The current weakmap implementation is really horrifying (using eval, trying to parse function names, etc). It seems to be no longer maintained.

It also breaks in CocoonJS, and in Safari 7.0.3 after UglifyJS (mangle + compress) because of the strange crap it's using. 

This is a drop in change to use [weak-map](https://www.npmjs.org/package/weak-map), which fixes these problems and seems to work fine for all the demos I've tested so far. Hopefully it can come in a patch to ease the upgrade across all the dozens of modules that rely on webglew in one way or another. 
